### PR TITLE
Force python2 usage and provide Ubuntu install scripts for Focal

### DIFF
--- a/bin/fwbackups-run.py
+++ b/bin/fwbackups-run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 #  Copyright (C) 2005, 2006, 2007, 2008, 2009 Stewart Adam
 #  This file is part of fwbackups.
@@ -137,4 +137,3 @@ if __name__ == "__main__":
     if backupThread.retval == -1:
       logger.logmsg('WARNING', _('There was an error while performing the backup!'))
       logger.logmsg('ERROR', backupThread.traceback)
-

--- a/bin/fwbackups-runonce.py
+++ b/bin/fwbackups-runonce.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 #  Copyright (C) 2007, 2008, 2009 Stewart Adam
 #  This file is part of fwbackups.
@@ -193,6 +193,3 @@ if __name__ == "__main__":
   if backupThread.retval == -1:
     logger.logmsg('WARNING', _('There was an error while performing the backup!'))
     logger.logmsg('ERROR', backupThread.traceback)
-
-
-

--- a/bin/fwbackups.in
+++ b/bin/fwbackups.in
@@ -27,4 +27,4 @@ prefix="@prefix@"
 datarootdir="@datarootdir@"
 
 # Expands to ${prefix}/share OR ${datarootdir}, which is defined above
-python "@datadir@/fwbackups/fwbackups-runapp.pyw" "$@"
+python2 "@datadir@/fwbackups/fwbackups-runapp.pyw" "$@"

--- a/edit_dpkg_status
+++ b/edit_dpkg_status
@@ -1,0 +1,35 @@
+#!/usr/bin/python3
+
+import os
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument('packages', type=str, nargs='*',
+                    help='space separated list of python packages to remove dependencies in /var/lib/dpkg/status')
+parser.add_argument('--debug', action='store_true', default=False)
+args = parser.parse_args()
+
+exclude_depends = ['python', 'python:any', 'python-is-python2']
+
+def remove_specific_depends(depends_line):
+    dependencies = depends_line.replace('Depends: ', '').replace('\n', '').split(',')
+    new_dependencies = [d for d in dependencies if d.split()[0] not in exclude_depends]
+    if new_dependencies:
+        return 'Depends: ' + ', '.join(new_dependencies) + '\n'
+    else:
+        return None
+
+with open('/var/lib/dpkg/status' if not args.debug else 'status', 'r') as f:
+    with open('status_new', 'w') as f_new:
+        remove_depends = False
+        for line in f:
+            if line.startswith('Package:'):
+                # start new package block
+                package = line.split()[1]
+                remove_depends = package in args.packages
+            if line.startswith('Depends') and remove_depends:
+                new_line = remove_specific_depends(line)
+                if new_line is not None:
+                    f_new.write(new_line)
+            else:
+                f_new.write(line)

--- a/install_ubuntu_focal.sh
+++ b/install_ubuntu_focal.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Install script for Ubuntu 20.04 Focal which manually grabs the python 2 packages from the 18.04 Bionic distribution
+# and installs a modified version of fwbackups which forces python2 usage.
+set -e
+
+PREFIX=/usr/local
+# https://stackoverflow.com/questions/192249/how-do-i-parse-command-line-arguments-in-bash
+for i in "$@"; do
+  case $i in
+    --prefix=*)
+      PREFIX="${i#*=}"
+      shift # past argument=value
+      ;;
+    -*|--*)
+      echo "Unknown option $i"
+      exit 1
+      ;;
+    *)
+      echo "Unknown argument $i"
+      exit 1
+      ;;
+  esac
+done
+PATH=${PREFIX}/bin:${PATH}
+
+# add bionic sources to apt (will remove after install)
+release=bionic; cat > "/etc/apt/sources.list.d/$release.list"<<EOF
+deb http://archive.ubuntu.com/ubuntu $release universe
+deb http://archive.ubuntu.com/ubuntu $release multiverse
+deb http://security.ubuntu.com/ubuntu $release-security main
+EOF
+apt update
+
+apt install autotools-dev x11-apps tzdata build-essential
+apt install cron gettext intltool
+apt install python2.7
+
+# can install this list of packages without hacking depends
+apt install libatk-adaptor libgtk2.0-0 libglade2-0 libglib2.0-0 python-cairo python-gobject-2 python-cryptography python-enum34 python-crypto
+
+# manually obtained dependency list excluding python-is-python2,python,python:any needed to install packages list below
+declare -a packages=( "python-paramiko" "python-gtk2" "python-glade2" "python-notify" )
+for p in "${packages[@]}" ; do
+  echo "Installing $p and fixing dependencies"
+  apt download $p
+  dpkg --force-depends -i "$p"*.deb
+  rm "$p"*.deb
+  # edit /var/lib/dpkg/status to remove Depends line from package
+  ./edit_dpkg_status $p
+  diff /var/lib/dpkg/status status_new || true   # exit 1 if different which they are
+  mv status_new /var/lib/dpkg/status
+done
+
+# remove bionic sources from apt
+rm -f /etc/apt/sources.list.d/$release.list
+apt update
+
+# configure and build fwbackups from source which has been modified to use python2
+./autogen.sh
+PYTHON=python2 ./configure --prefix=${PREFIX}
+make install

--- a/uninstall_ubuntu_focal.sh
+++ b/uninstall_ubuntu_focal.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+apt remove libglade2-0 python-cairo python-gobject-2 python-cryptography python-enum34 python-crypto
+apt remove python-paramiko python-gtk2 python-glade2 python-notify
+make uninstall


### PR DESCRIPTION
I ran into the same issue as #13 and have been trying to find a good solution since upgrading to Ubuntu Focal 20.04. Previously had it working on Ubuntu 18.04 (Bionic) with no problems.

Python2 and Python3 can both coexist on the same system without conflict as all libraries are installed in separate site-packages directories and only the Python? directories are used in the Python path when invoking the correct interpreter version. It is Ubuntu's package management system that will not allow both to coexist, by using the python-is-python? package to force one version or the other. You can get this to work quite easily by adding bionic sources and using python-is-python2 and then continuing with install as before, but then everything on your system is limited to python2, which is not a good solution.

Therefore I managed to install fwbackups by installing the dependencies and hacking the dependencies file to remove the dependencies which forced the python2 version. Then with just some simple modifications to the fwbackups scripts to point explicitly to python2, and making sure python2 is specified when running configure, and everything now worked as usual. The method was quite tricky so I made a script to automate it and made this PR for visibility in case anyone else wants to follow the same procedure.