### PR TITLE
Prevent flatpak-spawn debug messages from polluting stdout

### DIFF
--- a/fwbackups/__init__.py
+++ b/fwbackups/__init__.py
@@ -19,6 +19,7 @@ fwbackups package initialization.
 """
 import os
 import sys
+import shutil
 import subprocess
 
 from threading import Thread
@@ -64,11 +65,11 @@ def executeSub(command, env=None, shell=False, stdoutfd=None, text=True):
     if env is None:
         env = {}
 
-    if constants.IS_FLATPAK:
+        flatpak_spawn = shutil.which("flatpak-spawn")
         if type(command) is list:
-            command = ['flatpak-spawn', '--host'] + command
+            command = [flatpak_spawn, '--host'] + command
         else:
-            command = 'flatpak-spawn --host ' + command
+            command = f'{flatpak_spawn} --host {command}'
 
     sub = subprocess.Popen(encode(command), stdin=subprocess.PIPE, stdout=stdoutfd, stderr=subprocess.PIPE, shell=shell, env=dict(os.environ, **env), text=text)
     return sub


### PR DESCRIPTION
When editing crontab, if the user or system has set the `G_DEBUG` or `G_DEBUG_MESSAGES` environment variables, then flakpat-spawn injects its own output into the captured stdout of executed commands, breaking crontab parsing.

This PR removes `G_DEBUG` and `G_DEBUG_MESSAGES` from the cloned environment for subprocesses when executing in a flatpak environment to avoid this.