### PR TITLE
Python 3.12 compat for ConfigParser

### DIFF
--- a/fwbackups/config.py
+++ b/fwbackups/config.py
@@ -98,7 +98,7 @@ class ConfigFile(configparser.ConfigParser):
     def read(self):
         """Read and parse the configuration file's data."""
         fh = open(self.__conffile, 'r', encoding="UTF-8")
-        configparser.ConfigParser.readfp(self, fh)
+        configparser.ConfigParser.read_file(self, fh)
         fh.close()
 
     def generateDict(self, sections=None):


### PR DESCRIPTION
Adds compatibility with Python 3.12 after deprecated `ConfigParser.readfp()` was removed.