### PR TITLE
Avoid locked up UI after closing backupset window without pressing cancel button

### DIFF
--- a/fwbackups/ui/gtk/backupset.ui
+++ b/fwbackups/ui/gtk/backupset.ui
@@ -9,7 +9,7 @@
     <property name="destroy-with-parent">True</property>
     <property name="icon-name">document-edit-symbolic</property>
     <property name="title" translatable="yes">Configure Set</property>
-    <signal name="close-request" handler="hide"/>
+    <signal name="close-request" handler="on_backupsetCancelButton_clicked"/>
     <child>
       <object class="GtkGrid" id="table75">
         <property name="column-spacing">12</property>


### PR DESCRIPTION
Closing the window using Alt+F4 or pressing the 'X' button would call `hide()` without triggering the associated backupset window cancellation tasks to unlock the main window UI. This PR addresses this bug.